### PR TITLE
refactor(#7): reconcile logic

### DIFF
--- a/kubernetes/traffic-target-crd.yml
+++ b/kubernetes/traffic-target-crd.yml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: traffictargets.bb.traffic-maker.com
+  name: traffictargets.bb.com
 spec:
-  group: bb.traffic-maker.com
+  group: bb.com
   names:
     kind: TrafficTarget
     plural: traffictargets
@@ -42,8 +42,6 @@ spec:
                   enum:
                     - SCHEDULING
                     - FAILURE
-                    - UPDATING
-                    - INITIALIZING
                   type: string
               type: object
           type: object

--- a/kubernetes/traffic-target-crd.yml
+++ b/kubernetes/traffic-target-crd.yml
@@ -12,55 +12,55 @@ spec:
       - tt
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            properties:
-              http:
-                properties:
-                  timeoutSeconds:
-                    type: integer
-                  uri:
-                    type: string
-                  headers:
-                    additionalProperties:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              properties:
+                http:
+                  properties:
+                    timeoutSeconds:
+                      type: integer
+                    uri:
                       type: string
-                    type: object
-                  body:
-                    type: string
-                  method:
-                    type: string
-                type: object
-              rate:
-                type: string
-            type: object
-          status:
-            properties:
-              status:
-                enum:
-                  - SCHEDULING
-                  - FAILURE
-                  - UPDATING
-                  - INITIALIZING
-                type: string
-            type: object
-        type: object
-    additionalPrinterColumns:
-      - name: Target URI
-        type: string
-        description: Target URI value
-        jsonPath: .spec.http.uri
-      - name: Rate
-        type: string
-        description: Scheduling rate
-        jsonPath: .spec.rate
-      - name: Status
-        type: string
-        description: TrafficTarget current status
-        jsonPath: .status.status
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                    headers:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    body:
+                      type: string
+                    method:
+                      type: string
+                  type: object
+                rate:
+                  type: string
+              type: object
+            status:
+              properties:
+                state:
+                  enum:
+                    - SCHEDULING
+                    - FAILURE
+                    - UPDATING
+                    - INITIALIZING
+                  type: string
+              type: object
+          type: object
+      additionalPrinterColumns:
+        - name: Target URI
+          type: string
+          description: Target URI value
+          jsonPath: .spec.http.uri
+        - name: Rate
+          type: string
+          description: Scheduling rate
+          jsonPath: .spec.rate
+        - name: State
+          type: string
+          description: TrafficTarget current state
+          jsonPath: .status.state
+      served: true
+      storage: true
+      subresources:
+        status: { }

--- a/kubernetes/traffic-target-sample.yml
+++ b/kubernetes/traffic-target-sample.yml
@@ -1,4 +1,4 @@
-apiVersion: bb.traffic-maker.com/v1alpha1
+apiVersion: bb.com/v1alpha1
 kind: TrafficTarget
 metadata:
   name: traffic-target-sample

--- a/src/main/java/com/kubernetes/trafficmaker/reconciler/TrafficMakerReconciler.java
+++ b/src/main/java/com/kubernetes/trafficmaker/reconciler/TrafficMakerReconciler.java
@@ -28,14 +28,14 @@ public class TrafficMakerReconciler implements Reconciler<TrafficTarget> {
     public UpdateControl<TrafficTarget> reconcile(TrafficTarget trafficTarget, Context context) {
         log.debug("Reconcile by trafficTarget {}", trafficTarget);
 
-        var state = trafficTarget.getStatus() != null
-                            ? trafficTarget.getStatus().state() : State.INITIALIZING;
         var taskName = trafficTarget.getMetadata().getName();
         var httpTargetSpec = trafficTarget.getSpec().http();
         var httpRequestMono = httpTargetSpec.toRequestMono(webClient);
         var period = DurationStyle.detectAndParse(trafficTarget.getSpec().rate());
+        var currentState = trafficTarget.getStatus() != null
+                                   ? trafficTarget.getStatus().state() : null;
 
-        if (state == State.SCHEDULING) {
+        if (currentState == State.SCHEDULING) {
             if (trafficScheduler.isScheduledTask(taskName)) {
                 trafficScheduler.updateFixedRateSchedule(taskName, httpRequestMono::subscribe, period);
             } else {

--- a/src/main/java/com/kubernetes/trafficmaker/reconciler/TrafficMakerReconciler.java
+++ b/src/main/java/com/kubernetes/trafficmaker/reconciler/TrafficMakerReconciler.java
@@ -75,7 +75,7 @@ public class TrafficMakerReconciler implements Reconciler<TrafficTarget> {
         var period = DurationStyle.detectAndParse(trafficTarget.getSpec().rate());
 
         if (trafficScheduler.isScheduledTask(taskName)) {
-            log.warn("Task {} is already scheduled task.", taskName);
+            log.error("Task {} is already scheduled task.", taskName);
             trafficTarget.updateTrafficTaskState(State.FAILURE);
         } else {
             trafficScheduler.addFixedRateSchedule(taskName, httpRequestMono::subscribe, period);

--- a/src/main/java/com/kubernetes/trafficmaker/schedule/TrafficScheduleTask.java
+++ b/src/main/java/com/kubernetes/trafficmaker/schedule/TrafficScheduleTask.java
@@ -1,0 +1,46 @@
+package com.kubernetes.trafficmaker.schedule;
+
+import com.kubernetes.trafficmaker.target.TrafficTargetSpec;
+import com.kubernetes.trafficmaker.target.TrafficTargetStatus.State;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.convert.DurationStyle;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@SuppressWarnings("ReactiveStreamsUnusedPublisher")
+@Slf4j
+public class TrafficScheduleTask {
+
+    private final String name;
+    private final TrafficTargetSpec target;
+    private final WebClient client;
+
+    private TrafficScheduleTask(String name, TrafficTargetSpec target, WebClient client) {
+        this.name = name;
+        this.target = target;
+        this.client = client;
+    }
+
+    public static TrafficScheduleTask of(String name, TrafficTargetSpec target, WebClient client) {
+        return new TrafficScheduleTask(name, target, client);
+    }
+
+    public State register(TrafficScheduler trafficScheduler, State currentTrafficState) {
+        var httpRequestMono = target.http().toRequestMono(client);
+        var period = DurationStyle.detectAndParse(target.rate());
+
+        if (trafficScheduler.isScheduledTask(name)) {
+            if (currentTrafficState == State.SCHEDULING) {
+                log.info("Task {} scheduling is updated", name);
+                trafficScheduler.updateFixedRateSchedule(name, httpRequestMono::subscribe, period);
+            } else {
+                log.error("Task {} is already scheduled task", name);
+                return State.FAILURE;
+            }
+        } else {
+            log.info("Task {} will be scheduled from now on", name);
+            trafficScheduler.addFixedRateSchedule(name, httpRequestMono::subscribe, period);
+        }
+        return State.SCHEDULING;
+    }
+
+}

--- a/src/main/java/com/kubernetes/trafficmaker/target/TrafficTarget.java
+++ b/src/main/java/com/kubernetes/trafficmaker/target/TrafficTarget.java
@@ -6,7 +6,7 @@ import io.fabric8.kubernetes.model.annotation.Group;
 import io.fabric8.kubernetes.model.annotation.Version;
 import lombok.extern.slf4j.Slf4j;
 
-@Group("bb.traffic-maker.com")
+@Group("bb.com")
 @Version("v1alpha1")
 @Slf4j
 public class TrafficTarget

--- a/src/main/java/com/kubernetes/trafficmaker/target/TrafficTarget.java
+++ b/src/main/java/com/kubernetes/trafficmaker/target/TrafficTarget.java
@@ -13,8 +13,8 @@ public class TrafficTarget
         extends CustomResource<TrafficTargetSpec, TrafficTargetStatus>
         implements Namespaced {
 
-    public void updateTrafficTaskStatus(TrafficTargetStatus.Status status) {
-        setStatus(new TrafficTargetStatus(status));
+    public void updateTrafficTaskState(TrafficTargetStatus.State state) {
+        setStatus(new TrafficTargetStatus(state));
     }
 
 }

--- a/src/main/java/com/kubernetes/trafficmaker/target/TrafficTargetStatus.java
+++ b/src/main/java/com/kubernetes/trafficmaker/target/TrafficTargetStatus.java
@@ -3,7 +3,6 @@ package com.kubernetes.trafficmaker.target;
 public record TrafficTargetStatus(State state) {
     public enum State {
 
-        INITIALIZING,
         SCHEDULING,
         FAILURE,
 

--- a/src/main/java/com/kubernetes/trafficmaker/target/TrafficTargetStatus.java
+++ b/src/main/java/com/kubernetes/trafficmaker/target/TrafficTargetStatus.java
@@ -1,7 +1,7 @@
 package com.kubernetes.trafficmaker.target;
 
-public record TrafficTargetStatus(Status status) {
-    public enum Status {
+public record TrafficTargetStatus(State state) {
+    public enum State {
         SCHEDULING,
         FAILURE,
         UPDATING,

--- a/src/main/java/com/kubernetes/trafficmaker/target/TrafficTargetStatus.java
+++ b/src/main/java/com/kubernetes/trafficmaker/target/TrafficTargetStatus.java
@@ -2,10 +2,11 @@ package com.kubernetes.trafficmaker.target;
 
 public record TrafficTargetStatus(State state) {
     public enum State {
+
+        INITIALIZING,
         SCHEDULING,
         FAILURE,
-        UPDATING,
-        INITIALIZING,
+
     }
 
 }

--- a/src/test/java/com/kubernetes/trafficmaker/reconciler/TrafficMakerReconcilerTest.java
+++ b/src/test/java/com/kubernetes/trafficmaker/reconciler/TrafficMakerReconcilerTest.java
@@ -104,7 +104,6 @@ class TrafficMakerReconcilerTest {
         var updateControl = trafficMakerReconciler.reconcile(trafficTarget, DEFAULT_CONTEXT);
 
         // then
-        assertThat(updateControl.isNoUpdate()).isTrue();
         assertThat(trafficTarget.getStatus().state()).isEqualTo(State.SCHEDULING);
         verify(trafficScheduler).updateFixedRateSchedule(eq(DEFAULT_RESOURCE_NAME), any(), eq(period));
     }
@@ -122,7 +121,6 @@ class TrafficMakerReconcilerTest {
         var updateControl = trafficMakerReconciler.reconcile(trafficTarget, DEFAULT_CONTEXT);
 
         // then
-        assertThat(updateControl.isNoUpdate()).isTrue();
         assertThat(trafficTarget.getStatus().state()).isEqualTo(State.SCHEDULING);
         verify(trafficScheduler).addFixedRateSchedule(eq(DEFAULT_RESOURCE_NAME), any(), eq(period));
     }

--- a/src/test/java/com/kubernetes/trafficmaker/reconciler/TrafficMakerReconcilerTest.java
+++ b/src/test/java/com/kubernetes/trafficmaker/reconciler/TrafficMakerReconcilerTest.java
@@ -5,7 +5,7 @@ import com.kubernetes.trafficmaker.target.HttpTargetSpec;
 import com.kubernetes.trafficmaker.target.TrafficTarget;
 import com.kubernetes.trafficmaker.target.TrafficTargetSpec;
 import com.kubernetes.trafficmaker.target.TrafficTargetStatus;
-import com.kubernetes.trafficmaker.target.TrafficTargetStatus.Status;
+import com.kubernetes.trafficmaker.target.TrafficTargetStatus.State;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.javaoperatorsdk.operator.api.reconciler.DefaultContext;
@@ -56,7 +56,7 @@ class TrafficMakerReconcilerTest {
 
         // then
         assertThat(updateControl.isUpdateStatus()).isTrue();
-        assertThat(trafficTarget.getStatus().status()).isEqualTo(Status.SCHEDULING);
+        assertThat(trafficTarget.getStatus().state()).isEqualTo(State.SCHEDULING);
         verify(trafficScheduler)
                 .addFixedRateSchedule(eq(DEFAULT_RESOURCE_NAME), any(), eq(period));
     }
@@ -74,7 +74,7 @@ class TrafficMakerReconcilerTest {
 
         // then
         assertThat(updateControl.isUpdateStatus()).isTrue();
-        assertThat(trafficTarget.getStatus().status()).isEqualTo(Status.FAILURE);
+        assertThat(trafficTarget.getStatus().state()).isEqualTo(State.FAILURE);
     }
 
     @DisplayName("Failure status인 경우 업데이트 되었을 수 있으니 UPDATING status로 업데이트하고 5초 뒤 reconcile 수행")
@@ -82,7 +82,7 @@ class TrafficMakerReconcilerTest {
     void update_status_to_UPDATING_and_after_5_seconds_reconcile_when_failure_status() {
         // given
         var trafficTarget = dummyTrafficTarget();
-        trafficTarget.setStatus(new TrafficTargetStatus(Status.FAILURE));
+        trafficTarget.setStatus(new TrafficTargetStatus(State.FAILURE));
 
         // when
         var updateControl = trafficMakerReconciler.reconcile(trafficTarget, DEFAULT_CONTEXT);
@@ -91,7 +91,7 @@ class TrafficMakerReconcilerTest {
         assertThat(updateControl.isUpdateStatus()).isTrue();
         assertThat(updateControl.getScheduleDelay()).isPresent();
         assertThat(updateControl.getScheduleDelay()).contains(Duration.ofSeconds(5).toMillis());
-        assertThat(trafficTarget.getStatus().status()).isEqualTo(Status.UPDATING);
+        assertThat(trafficTarget.getStatus().state()).isEqualTo(State.UPDATING);
     }
 
     @DisplayName("Scheduling status인 경우 spec 정보가 업데이트 되었을 수도 있으니 schedule task를 업데이트한다")
@@ -100,7 +100,7 @@ class TrafficMakerReconcilerTest {
         // given
         var trafficTarget = dummyTrafficTarget();
         var period = DurationStyle.detectAndParse(DEFAULT_RATE);
-        trafficTarget.setStatus(new TrafficTargetStatus(Status.SCHEDULING));
+        trafficTarget.setStatus(new TrafficTargetStatus(State.SCHEDULING));
         given(trafficScheduler.isScheduledTask(DEFAULT_RESOURCE_NAME))
                 .willReturn(true);
 
@@ -109,7 +109,7 @@ class TrafficMakerReconcilerTest {
 
         // then
         assertThat(updateControl.isNoUpdate()).isTrue();
-        assertThat(trafficTarget.getStatus().status()).isEqualTo(Status.SCHEDULING);
+        assertThat(trafficTarget.getStatus().state()).isEqualTo(State.SCHEDULING);
         verify(trafficScheduler)
                 .updateFixedRateSchedule(eq(DEFAULT_RESOURCE_NAME), any(), eq(period));
     }
@@ -120,7 +120,7 @@ class TrafficMakerReconcilerTest {
         // given
         var trafficTarget = dummyTrafficTarget();
         var period = DurationStyle.detectAndParse(DEFAULT_RATE);
-        trafficTarget.setStatus(new TrafficTargetStatus(Status.SCHEDULING));
+        trafficTarget.setStatus(new TrafficTargetStatus(State.SCHEDULING));
         given(trafficScheduler.isScheduledTask(DEFAULT_RESOURCE_NAME))
                 .willReturn(false);
 
@@ -129,7 +129,7 @@ class TrafficMakerReconcilerTest {
 
         // then
         assertThat(updateControl.isNoUpdate()).isTrue();
-        assertThat(trafficTarget.getStatus().status()).isEqualTo(Status.SCHEDULING);
+        assertThat(trafficTarget.getStatus().state()).isEqualTo(State.SCHEDULING);
         verify(trafficScheduler)
                 .addFixedRateSchedule(eq(DEFAULT_RESOURCE_NAME), any(), eq(period));
     }

--- a/src/test/java/com/kubernetes/trafficmaker/reconciler/TrafficMakerReconcilerTest.java
+++ b/src/test/java/com/kubernetes/trafficmaker/reconciler/TrafficMakerReconcilerTest.java
@@ -18,7 +18,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.convert.DurationStyle;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import java.time.Duration;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,8 +56,7 @@ class TrafficMakerReconcilerTest {
         // then
         assertThat(updateControl.isUpdateStatus()).isTrue();
         assertThat(trafficTarget.getStatus().state()).isEqualTo(State.SCHEDULING);
-        verify(trafficScheduler)
-                .addFixedRateSchedule(eq(DEFAULT_RESOURCE_NAME), any(), eq(period));
+        verify(trafficScheduler).addFixedRateSchedule(eq(DEFAULT_RESOURCE_NAME), any(), eq(period));
     }
 
     @DisplayName("첫 Reconcile - 중복된 이름의 schedule task가 있는 경우, 실패한다")
@@ -66,8 +64,7 @@ class TrafficMakerReconcilerTest {
     void first_reconcile_exist_duplicated_schedule_task_failure() {
         // given
         var trafficTarget = dummyTrafficTarget();
-        given(trafficScheduler.isScheduledTask(DEFAULT_RESOURCE_NAME))
-                .willReturn(true);
+        given(trafficScheduler.isScheduledTask(DEFAULT_RESOURCE_NAME)).willReturn(true);
 
         // when
         var updateControl = trafficMakerReconciler.reconcile(trafficTarget, DEFAULT_CONTEXT);
@@ -77,21 +74,21 @@ class TrafficMakerReconcilerTest {
         assertThat(trafficTarget.getStatus().state()).isEqualTo(State.FAILURE);
     }
 
-    @DisplayName("Failure status인 경우 업데이트 되었을 수 있으니 UPDATING status로 업데이트하고 5초 뒤 reconcile 수행")
+    @DisplayName("Failure state reconcile 시, 수정된 메니페스트가 정상적으로 등록이 가능하면 성공한다")
     @Test
-    void update_status_to_UPDATING_and_after_5_seconds_reconcile_when_failure_status() {
+    void success_valid_updated_manifest_when_failure_state() {
         // given
         var trafficTarget = dummyTrafficTarget();
         trafficTarget.setStatus(new TrafficTargetStatus(State.FAILURE));
+        var period = DurationStyle.detectAndParse(DEFAULT_RATE);
 
         // when
         var updateControl = trafficMakerReconciler.reconcile(trafficTarget, DEFAULT_CONTEXT);
 
         // then
         assertThat(updateControl.isUpdateStatus()).isTrue();
-        assertThat(updateControl.getScheduleDelay()).isPresent();
-        assertThat(updateControl.getScheduleDelay()).contains(Duration.ofSeconds(5).toMillis());
-        assertThat(trafficTarget.getStatus().state()).isEqualTo(State.UPDATING);
+        assertThat(trafficTarget.getStatus().state()).isEqualTo(State.SCHEDULING);
+        verify(trafficScheduler).addFixedRateSchedule(eq(DEFAULT_RESOURCE_NAME), any(), eq(period));
     }
 
     @DisplayName("Scheduling status인 경우 spec 정보가 업데이트 되었을 수도 있으니 schedule task를 업데이트한다")
@@ -101,8 +98,7 @@ class TrafficMakerReconcilerTest {
         var trafficTarget = dummyTrafficTarget();
         var period = DurationStyle.detectAndParse(DEFAULT_RATE);
         trafficTarget.setStatus(new TrafficTargetStatus(State.SCHEDULING));
-        given(trafficScheduler.isScheduledTask(DEFAULT_RESOURCE_NAME))
-                .willReturn(true);
+        given(trafficScheduler.isScheduledTask(DEFAULT_RESOURCE_NAME)).willReturn(true);
 
         // when
         var updateControl = trafficMakerReconciler.reconcile(trafficTarget, DEFAULT_CONTEXT);
@@ -110,8 +106,7 @@ class TrafficMakerReconcilerTest {
         // then
         assertThat(updateControl.isNoUpdate()).isTrue();
         assertThat(trafficTarget.getStatus().state()).isEqualTo(State.SCHEDULING);
-        verify(trafficScheduler)
-                .updateFixedRateSchedule(eq(DEFAULT_RESOURCE_NAME), any(), eq(period));
+        verify(trafficScheduler).updateFixedRateSchedule(eq(DEFAULT_RESOURCE_NAME), any(), eq(period));
     }
 
     @DisplayName("Scheduling status인 경우인데 schedule task가 존재하지 않는 경우, 현재 spec으로 schedule task를 추가한다")
@@ -121,8 +116,7 @@ class TrafficMakerReconcilerTest {
         var trafficTarget = dummyTrafficTarget();
         var period = DurationStyle.detectAndParse(DEFAULT_RATE);
         trafficTarget.setStatus(new TrafficTargetStatus(State.SCHEDULING));
-        given(trafficScheduler.isScheduledTask(DEFAULT_RESOURCE_NAME))
-                .willReturn(false);
+        given(trafficScheduler.isScheduledTask(DEFAULT_RESOURCE_NAME)).willReturn(false);
 
         // when
         var updateControl = trafficMakerReconciler.reconcile(trafficTarget, DEFAULT_CONTEXT);
@@ -130,8 +124,7 @@ class TrafficMakerReconcilerTest {
         // then
         assertThat(updateControl.isNoUpdate()).isTrue();
         assertThat(trafficTarget.getStatus().state()).isEqualTo(State.SCHEDULING);
-        verify(trafficScheduler)
-                .addFixedRateSchedule(eq(DEFAULT_RESOURCE_NAME), any(), eq(period));
+        verify(trafficScheduler).addFixedRateSchedule(eq(DEFAULT_RESOURCE_NAME), any(), eq(period));
     }
 
     @DisplayName("Clean up 수행 시, finalizer가 정상제거된다")
@@ -145,8 +138,7 @@ class TrafficMakerReconcilerTest {
 
         // then
         assertThat(deleteControl.isRemoveFinalizer()).isTrue();
-        verify(trafficScheduler)
-                .removeSchedule(DEFAULT_RESOURCE_NAME);
+        verify(trafficScheduler).removeSchedule(DEFAULT_RESOURCE_NAME);
     }
 
     TrafficTarget dummyTrafficTarget() {


### PR DESCRIPTION
- rename `Status` field to `State`.
- Remove duplicate logic of Reconcile according to `State`
- Create class `TrafficScheduleTask` responsible for scheduling task operation.
- remove `INITIALIZING`, `UPDATING` state.
- `TrafficTarget` CRD group to `bb.com`